### PR TITLE
Update Text.Json to match requirement from H.Formatters

### DIFF
--- a/src/libs/H.Ipc/H.Ipc.csproj
+++ b/src/libs/H.Ipc/H.Ipc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net4.6.2;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net4.6.2;net8.0</TargetFrameworks>
     <RootNamespace>H.Ipc.Core</RootNamespace>
   </PropertyGroup>
 
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.2" />
     <ProjectReference Include="..\H.Ipc.Generator\H.Ipc.Generator.csproj" ReferenceOutputAssembly="false" PackAsAnalyzer="true" />
     <PackageReference Include="H.Formatters.System.Text.Json" Version="15.0.0" />
     <PackageReference Include="H.Generators.Extensions" Version="1.24.1" PrivateAssets="all" IncludeInPackage="true" />


### PR DESCRIPTION
H.Formatters.System.Text.Json v15 has been updated to require System.Text.Json > 9.0.0 which leads to a conflict as H.Ipc references System.Text.Json = 8.0.0, additionally System.Text.Json 8.0.0 has a known vulnerability.

Additionally the multi-target .net6 was removed, as it's out of support and generates a warning with System.Text.Json 9